### PR TITLE
Fix for bug #32

### DIFF
--- a/ftpsync.default-settings
+++ b/ftpsync.default-settings
@@ -65,6 +65,12 @@
 		// can be used for increase of performance or to allow build scripts to finish
 		//"upload_delay": 0,
 
+		// If the server you're working with is in a different timezone, you can specify the offset here
+		// in seconds.  For example, if the FTP server is 1 hour ahead of you, use -3600 as the offset to
+		// make comparisons against the server time take 3600 seconds off of the server time.
+		//"time_offset": 0,
+
+
 		// chmod value for directories created on remote server by FTPSync
 		//"default_folder_permissions": "755",
 

--- a/ftpsync.sublime-settings
+++ b/ftpsync.sublime-settings
@@ -25,6 +25,7 @@
 		"upload_delay": 0,
 		"default_folder_permissions": "755",
 		"line_separator": "\n",
+		"time_offset": 0,
 
 		"after_save_watch": null,
 

--- a/ftpsyncwrapper.py
+++ b/ftpsyncwrapper.py
@@ -391,7 +391,7 @@ class FTPSConnection(AbstractConnection):
                 lastModified = split.group(3)
                 name = split.group(4)
 
-                data = Metafile(name, isDir, self.__parseTime(lastModified), filesize)
+                data = Metafile(name, isDir, self.__parseTime(lastModified) + self.config['time_offset'], filesize)
 
                 if name != "." and name != "..":
                     result.append(data)


### PR DESCRIPTION
FTP servers in different time zones cause a problem since FTP LIST output doesn't state what timezone the information is listed in. time_offset is added to the server time for each file so you can
add/subtract time for comparison purposes.

I did some mild testing to ensure that the default setting of 0 was applied if you didn't specify the setting in your connection's configuration.  
